### PR TITLE
Pass extra arguments to log handlers

### DIFF
--- a/gamemode/core/libs/sh_log.lua
+++ b/gamemode/core/libs/sh_log.lua
@@ -107,7 +107,7 @@ if (SERVER) then
 
 		Msg("[LOG] ", logString .. "\n")
 
-		ix.log.CallHandler("Write", client, logString, logFlag)
+		ix.log.CallHandler("Write", client, logString, logFlag, logType, {...})
 	end
 
 	function ix.log.Send(client, logString, flag)


### PR DESCRIPTION
This commit passes the log type and more importantly the arguments to the "Write" log handler event. These extra arguments would help developers write better log handlers that can give more useful information to server staff such as item or character ID's.

Because this change does not affect the order of the arguments, this would not break existing log handlers.